### PR TITLE
chore: refactor CI workflow for Docker image build and push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  test-and-build:
+  build-and-push:
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -15,38 +15,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint code
-        run: npm run lint
-
-      - name: Run tests
-        run: npm test
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/cloud-file-storage:latest
-            ghcr.io/${{ github.repository_owner }}/cloud-file-storage:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max 
+      - name: Build and Tag Docker Image
+        run: |
+          docker build \
+            -t ghcr.io/${{ github.repository_owner }}/cloud-file-storage:latest .
+
+      - name: Push Image to GHCR
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/cloud-file-storage:latest 


### PR DESCRIPTION
- Renamed job from 'test-and-build' to 'build-and-push' for clarity.
- Removed Node.js setup, dependency installation, and testing steps to streamline the workflow.
- Updated Docker login method and added separate steps for building and pushing the Docker image to GitHub Container Registry.